### PR TITLE
feat: Add Rotary Encoder with BEMF Example

### DIFF
--- a/examples/RotaryEncoderWithBEMF/README.md
+++ b/examples/RotaryEncoderWithBEMF/README.md
@@ -1,14 +1,12 @@
-# Rotary Encoder Control with BEMF Reading Example
+# Low-Level HAL Motor Control with Rotary Encoder
 
-This example demonstrates how to control the motor's speed and direction using a standard KY-040 rotary encoder and read the motor's speed using BEMF.
+This example demonstrates how to use the Hardware Abstraction Layer (HAL) for direct, low-level motor control. It shows how to control the motor's PWM duty cycle with a rotary encoder and receive raw BEMF data through a callback.
 
 ## How it Works
 
-- **Speed Control:** Turning the encoder knob increases or decreases the motor's target speed. One full rotation of a 24-detent encoder will ramp the speed from 0 to 100%.
-- **Stop & Direction Control:** Pressing the encoder's push-button has two functions:
-  1. If the motor is currently moving, it acts as an emergency stop, setting the target speed to 0.
-  2. If the motor is stopped, it toggles the direction of travel for the next time the motor starts (Forward -> Reverse -> Forward).
-- **BEMF Reading:** The motor's speed is continuously measured using BEMF and printed to the serial port.
+- **PWM Control:** Turning the encoder directly adjusts the PWM duty cycle sent to the motor, ranging from 0 to 255.
+- **Stop & Direction:** Pressing the encoder's button will stop the motor or toggle its direction.
+- **BEMF Callback:** BEMF data is received via an interrupt-driven callback and printed to the serial port. This example does not perform any filtering or processing on the raw BEMF values.
 
 ## Hardware Setup
 


### PR DESCRIPTION
This commit introduces a new example that demonstrates how to control a motor's speed using a rotary encoder and read its BEMF value.

The example is based on the existing RotaryEncoderControl example, but it adds a serial printout of the BEMF readings. The README has also been updated to reflect the new functionality.