### PR TITLE
Fix: Trigger release workflow on creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '*'
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   build:


### PR DESCRIPTION
The GitHub Actions workflow for building and releasing firmware was not being triggered when a new release was tagged. This was because the workflow was configured to run on the `published` event, which only fires when a release is made public.

This change updates the trigger to the `created` event, which fires as soon as a release is created (draft or public). This ensures that the build and upload process starts immediately, aligning with the expected behavior of attaching firmware assets to the release as it's being prepared.