### PR TITLE
Fix: Update release workflow and prefix firmware names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '*'
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   build:
@@ -35,9 +35,9 @@ jobs:
       - name: Rename Firmware
         run: |
           if [ "${{ matrix.platform }}" == "seeed_xiao_rp2040" ]; then
-            mv .pio/build/${{ matrix.platform }}/firmware.uf2 ${{ matrix.platform }}.uf2
+            mv .pio/build/${{ matrix.platform }}/firmware.uf2 xDuinoRails_MotorControl_bEMF_${{ matrix.platform }}.uf2
           else
-            mv .pio/build/${{ matrix.platform }}/firmware.bin ${{ matrix.platform }}.bin
+            mv .pio/build/${{ matrix.platform }}/firmware.bin xDuinoRails_MotorControl_bEMF_${{ matrix.platform }}.bin
           fi
 
       - name: Upload firmware as artifact
@@ -45,7 +45,7 @@ jobs:
         with:
           name: ${{ matrix.platform }}-firmware
           path: |
-            ${{ matrix.platform }}.*
+            xDuinoRails_MotorControl_bEMF_${{ matrix.platform }}.*
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit addresses two issues with the GitHub Actions release workflow:

1.  The workflow was not being triggered on release creation because it was configured to run on the `published` event. This has been changed to `created` to ensure the workflow runs as soon as a release is created (draft or public).

2.  The firmware filenames have been updated to include the prefix "xDuinoRails_MotorControl_bEMF_", as requested. The "Rename Firmware" and "Upload firmware as artifact" steps have been updated to reflect this change.