### PR TITLE
Refactor: Rename project to XDuinoRails Motor Driver bEMF

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = "XDuinoRails Motor Driver"
+PROJECT_NAME           = "XDuinoRails Motor Driver bEMF"
 PROJECT_NUMBER         =
 PROJECT_BRIEF          = "A powerful, closed-loop motor driver library for Arduino and PlatformIO"
 PROJECT_LOGO           =

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# XDuinoRails Motor Driver
+# XDuinoRails Motor Driver bEMF
 
 A powerful, closed-loop motor driver library for Arduino and PlatformIO, designed for controlling DC motors with high precision. This library is ideal for projects like model trains, robotics, or any application that requires smooth and accurate speed control.
 


### PR DESCRIPTION
This commit renames the project from "XDuinoRails Motor Driver" to "XDuinoRails Motor Driver bEMF" to more accurately reflect the project's focus on back-EMF based motor control.

The following files were updated:
- Doxyfile: Updated the PROJECT_NAME to "XDuinoRails Motor Driver bEMF".
- readme.md: Updated the main title to "XDuinoRails Motor Driver bEMF".