### PR TITLE
Fix: Correct failing CI build by removing missing requirements file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade platformio
-          pip install -r scripts/requirements.txt
 
       - name: Build Firmware
         env:


### PR DESCRIPTION
The GitHub Actions workflow was failing because it attempted to install Python dependencies from `scripts/requirements.txt`, which does not exist. This commit removes the unnecessary `pip install` command to resolve the build error.