### PR TITLE
fix(ci): add missing examples to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,9 @@ jobs:
           - nucleo_f446re
           - seeed_xiao_samd21
         example:
-          - CustomControlLoop
+          - FiftyPercent
           - RotaryEncoderWithBEMF
+          - SineWaveSpeed
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The `build.yml` workflow was not building the `FiftyPercent` and `SineWaveSpeed` examples. This change updates the build matrix to include these examples, ensuring they are built and included in the release assets. It also removes the non-existent `CustomControlLoop` example.