### PR TITLE
feat: Restrict release assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,16 @@ jobs:
           - nucleo_f446re
           - seeed_xiao_samd21
         example:
-          - FiftyPercent
-          - RotaryEncoderWithBEMF
           - SineWaveSpeed
+        include:
+          - platform: seeed_xiao_rp2040
+            example: FiftyPercent
+          - platform: seeed_xiao_rp2040_led
+            example: FiftyPercent
+          - platform: seeed_xiao_rp2040
+            example: RotaryEncoderWithBEMF
+          - platform: seeed_xiao_rp2040_led
+            example: RotaryEncoderWithBEMF
 
     steps:
       - name: Checkout repository

--- a/examples/FiftyPercent/FiftyPercent.ino
+++ b/examples/FiftyPercent/FiftyPercent.ino
@@ -16,11 +16,19 @@
 
 // --- Pin Definitions ---
 #if defined(ARDUINO_SEEED_XIAO_RP2040)
-// For Seeed XIAO RP2040
-const int MOTOR_PWM_A_PIN       =  D9;
-const int MOTOR_PWM_B_PIN       = D10;
-const int MOTOR_BEMF_A_PIN      =  D7;
-const int MOTOR_BEMF_B_PIN      =  D8;
+    #ifdef LED_EDITION
+        // For Seeed XIAO RP2040 "LED Edition"
+        const int MOTOR_PWM_A_PIN       = 17; // Red LED
+        const int MOTOR_PWM_B_PIN       = 16; // Green LED
+        const int MOTOR_BEMF_A_PIN      = D7;
+        const int MOTOR_BEMF_B_PIN      = D8;
+    #else
+        // For standard Seeed XIAO RP2040
+        const int MOTOR_PWM_A_PIN       =  D9;
+        const int MOTOR_PWM_B_PIN       = D10;
+        const int MOTOR_BEMF_A_PIN      =  D7;
+        const int MOTOR_BEMF_B_PIN      =  D8;
+    #endif
 #else
 // Default pins for other boards
 const int MOTOR_PWM_A_PIN       =   7;

--- a/examples/SineWaveSpeed/SineWaveSpeed.ino
+++ b/examples/SineWaveSpeed/SineWaveSpeed.ino
@@ -20,11 +20,19 @@
 
 // --- Pin Definitions ---
 #if defined(ARDUINO_SEEED_XIAO_RP2040)
-// For Seeed XIAO RP2040
-const int MOTOR_PWM_A_PIN       =  D9;
-const int MOTOR_PWM_B_PIN       = D10;
-const int MOTOR_BEMF_A_PIN      =  D7;
-const int MOTOR_BEMF_B_PIN      =  D8;
+    #ifdef LED_EDITION
+        // For Seeed XIAO RP2040 "LED Edition"
+        const int MOTOR_PWM_A_PIN       = 17; // Red LED
+        const int MOTOR_PWM_B_PIN       = 16; // Green LED
+        const int MOTOR_BEMF_A_PIN      = D7;
+        const int MOTOR_BEMF_B_PIN      = D8;
+    #else
+        // For standard Seeed XIAO RP2040
+        const int MOTOR_PWM_A_PIN       =  D9;
+        const int MOTOR_PWM_B_PIN       = D10;
+        const int MOTOR_BEMF_A_PIN      =  D7;
+        const int MOTOR_BEMF_B_PIN      =  D8;
+    #endif
 #else
 // Default pins for other boards
 const int MOTOR_PWM_A_PIN       =   7;


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow to reduce the number of release assets.

The `SineWaveSpeed` example is now built for all platforms, while the `FiftyPercent` and `RotaryEncoderWithBEMF` examples are only built for the `seeed_xiao_rp2040` and `seeed_xiao_rp2040_led` platforms.