### PR TITLE
feat: Add implementation roadmap for unsupported boards

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,37 @@
+# Implementation Roadmap
+
+This document outlines the plan for adding support for currently unsupported Seeed Studio XIAO boards to this library.
+
+## Seeed XIAO ESP32-S3 / ESP32-S3 Sense
+
+- [ ] Implement the Hardware Abstraction Layer (HAL) for the ESP32-S3.
+- [ ] Add a new PlatformIO environment for the `seeed_xiao_esp32s3` board.
+- [ ] Verify that all examples compile successfully for the new platform.
+- [ ] Perform on-hardware testing and validation.
+- [ ] Add documentation for the Seeed XIAO ESP32-S3.
+
+## Seeed XIAO nRF52840 / nRF52840 Sense
+
+- [ ] Implement the Hardware Abstraction Layer (HAL) for the nRF52840.
+- [ ] Add a new PlatformIO environment for the `seeed_xiao_nrf52840` board.
+- [ ] Verify that all examples compile successfully for the new platform.
+- [ ] Perform on-hardware testing and validation.
+- [ ] Add documentation for the Seeed XIAO nRF52840.
+
+## Seeed XIAO EFR32MG24 (MG24 Sense)
+
+- [ ] Research PlatformIO support for the EFR32MG24.
+- [ ] Implement the Hardware Abstraction Layer (HAL) for the EFR32MG24.
+- [ ] Add a new PlatformIO environment for the `seeed_xiao_mg24` board.
+- [ ] Verify that all examples compile successfully for the new platform.
+- [ ] Perform on-hardware testing and validation.
+- [ ] Add documentation for the Seeed XIAO EFR32MG24.
+
+## Seeed XIAO RP2350
+
+- [ ] Research PlatformIO support for the RP2350.
+- [ ] Implement the Hardware Abstraction Layer (HAL) for the RP2350.
+- [ ] Add a new PlatformIO environment for the `seeed_xiao_rp2350` board.
+- [ ] Verify that all examples compile successfully for the new platform.
+- [ ] Perform on-hardware testing and validation.
+- [ ] Add documentation for the Seeed XIAO RP2350.


### PR DESCRIPTION
Creates a new ROADMAP.md file to track the progress of adding support for currently unsupported Seeed Studio XIAO boards, including the ESP32-S3, nRF52840, EFR32MG24, and RP2350.