### PR TITLE
fix: filename duplication, add version tag, and enable Neopixel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,10 @@ jobs:
       - name: Rename Firmware and Set Path
         id: rename
         run: |
+          VERSION="${{ github.ref_name }}"
+          SAFE_VERSION=$(echo "$VERSION" | tr '/' '-')
           FIRMWARE_BASENAME="xDuinoRails_MotorControl_bEMF-"
+          FIRMWARE_BASENAME="${FIRMWARE_BASENAME}${SAFE_VERSION}-"
           FIRMWARE_BASENAME="${FIRMWARE_BASENAME}${{ matrix.example }}-"
           FIRMWARE_BASENAME="${FIRMWARE_BASENAME}${{ matrix.platform }}"
           BUILD_DIR=".pio/build/${{ matrix.platform }}"
@@ -69,7 +72,6 @@ jobs:
 
           if [[ "${{ matrix.platform }}" == "seeed_xiao_rp2040_led" ]]; then
             EXTENSION="uf2"
-            SUFFIX="_led"
           elif [[ "${{ matrix.platform }}" == "seeed_xiao_rp2040" ]]; then
             EXTENSION="uf2"
           elif [[ "${{ matrix.platform }}" == *"nrf52"* ]]; then
@@ -108,11 +110,13 @@ jobs:
       - name: Prepare Artifacts
         working-directory: rust
         run: |
+          VERSION="${{ github.ref_name }}"
+          SAFE_VERSION=$(echo "$VERSION" | tr '/' '-')
           mkdir -p output
           # Copy ELF
-          cp target/thumbv7em-none-eabihf/release/sine_wave_controller output/xDuinoRails_MotorControl_bEMF-SineWaveSpeed-nucleo_g431rb_rust.elf
+          cp target/thumbv7em-none-eabihf/release/sine_wave_controller output/xDuinoRails_MotorControl_bEMF-${SAFE_VERSION}-SineWaveSpeed-nucleo_g431rb_rust.elf
           # Create BIN
-          arm-none-eabi-objcopy -O binary target/thumbv7em-none-eabihf/release/sine_wave_controller output/xDuinoRails_MotorControl_bEMF-SineWaveSpeed-nucleo_g431rb_rust.bin
+          arm-none-eabi-objcopy -O binary target/thumbv7em-none-eabihf/release/sine_wave_controller output/xDuinoRails_MotorControl_bEMF-${SAFE_VERSION}-SineWaveSpeed-nucleo_g431rb_rust.bin
 
       - name: Upload Rust artifact
         uses: actions/upload-artifact@v4

--- a/examples/FiftyPercent/FiftyPercent.ino
+++ b/examples/FiftyPercent/FiftyPercent.ino
@@ -14,6 +14,10 @@
 #include <Arduino.h>
 #include "motor_control_hal.h"
 
+#ifdef LED_EDITION
+#include <Adafruit_NeoPixel.h>
+#endif
+
 // --- Pin Definitions ---
 #if defined(ARDUINO_SEEED_XIAO_RP2040)
     #ifdef LED_EDITION
@@ -22,6 +26,11 @@
         const int MOTOR_PWM_B_PIN       = 16; // Green LED
         const int MOTOR_BEMF_A_PIN      = D7;
         const int MOTOR_BEMF_B_PIN      = D8;
+
+        // --- Neopixel LED for LED_EDITION ---
+        #define NEOPIXEL_PIN 12
+        #define NEOPIXEL_POWER_PIN 11
+        Adafruit_NeoPixel pixels(1, NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
     #else
         // For standard Seeed XIAO RP2040
         const int MOTOR_PWM_A_PIN       =  D9;
@@ -60,6 +69,16 @@ void setup() {
   const int fifty_percent_speed =  127;
   const bool forward_direction  = true;
   hal_motor_set_pwm(fifty_percent_speed, forward_direction);
+
+#ifdef LED_EDITION
+  // Initialize Neopixel for LED_EDITION
+  pinMode(NEOPIXEL_POWER_PIN, OUTPUT);
+  digitalWrite(NEOPIXEL_POWER_PIN, HIGH);
+  delay(10); // Wait for power to stabilize
+  pixels.begin();
+  pixels.setPixelColor(0, pixels.Color(0, 255, 0)); // Green to indicate 50% speed
+  pixels.show();
+#endif
 
   Serial.println("Motor running at 50% speed.");
 }

--- a/examples/RotaryEncoderWithBEMF/RotaryEncoderWithBEMF.ino
+++ b/examples/RotaryEncoderWithBEMF/RotaryEncoderWithBEMF.ino
@@ -125,6 +125,7 @@ void setup() {
   // Initialize Neopixel for LED_EDITION
   pinMode(NEOPIXEL_POWER_PIN, OUTPUT);
   digitalWrite(NEOPIXEL_POWER_PIN, HIGH);
+  delay(10); // Wait for power to stabilize
   pixels.begin();
   pixels.setPixelColor(0, pixels.Color(255, 0, 0)); // Red for stop
   pixels.show();

--- a/examples/SineWaveSpeed/SineWaveSpeed.ino
+++ b/examples/SineWaveSpeed/SineWaveSpeed.ino
@@ -18,6 +18,10 @@
 #include "motor_control_hal.h"
 #include "StatusLED.h"
 
+#ifdef LED_EDITION
+#include <Adafruit_NeoPixel.h>
+#endif
+
 // --- Pin Definitions ---
 #if defined(ARDUINO_SEEED_XIAO_RP2040)
     #ifdef LED_EDITION
@@ -26,6 +30,11 @@
         const int MOTOR_PWM_B_PIN       = 16; // Green LED
         const int MOTOR_BEMF_A_PIN      = D7;
         const int MOTOR_BEMF_B_PIN      = D8;
+
+        // --- Neopixel LED for LED_EDITION ---
+        #define NEOPIXEL_PIN 12
+        #define NEOPIXEL_POWER_PIN 11
+        Adafruit_NeoPixel pixels(1, NEOPIXEL_PIN, NEO_GRB + NEO_KHZ800);
     #else
         // For standard Seeed XIAO RP2040
         const int MOTOR_PWM_A_PIN       =  D9;
@@ -65,6 +74,16 @@ void setup() {
   // Initialize the status LED.
   status_led.begin();
   status_led.on();
+
+#ifdef LED_EDITION
+  // Initialize Neopixel for LED_EDITION
+  pinMode(NEOPIXEL_POWER_PIN, OUTPUT);
+  digitalWrite(NEOPIXEL_POWER_PIN, HIGH);
+  delay(10); // Wait for power to stabilize
+  pixels.begin();
+  pixels.setPixelColor(0, pixels.Color(0, 0, 255)); // Blue to indicate SineWave mode
+  pixels.show();
+#endif
 }
 
 void loop() {


### PR DESCRIPTION
- CI: Remove duplicate `_led` suffix in `build.yml` for `seeed_xiao_rp2040_led`.
- CI: Inject sanitized git ref (version) into firmware filenames for both PlatformIO and Rust artifacts.
- Fix: Add initialization logic (enable power on pin 11) for Neopixel in `SineWaveSpeed` and `FiftyPercent` examples for `LED_EDITION`.
- Fix: Add stabilization delay for Neopixel power in `RotaryEncoderWithBEMF`.