### PR TITLE
feat: Make PWM frequency configurable in HAL

### DIFF
--- a/examples/SineWaveSpeed/SineWaveSpeed.ino
+++ b/examples/SineWaveSpeed/SineWaveSpeed.ino
@@ -56,7 +56,7 @@ const int STATUS_LED_PIN        = LED_BUILTIN;
 StatusLED status_led(STATUS_LED_PIN);
 
 // --- Sine Wave Parameters ---
-const float SINE_WAVE_PERIOD    = 2500; // 2.5 seconds in milliseconds
+const float SINE_WAVE_PERIOD    = 3000; // 3.0 seconds in milliseconds
 const int MIN_PWM_DUTY_CYCLE    =    0;   // 0% of 255
 const int MAX_PWM_DUTY_CYCLE    =  191;  // 75% of 255
 bool motorDirection             = true;   // Motor direction: true for forward
@@ -69,7 +69,7 @@ void setup() {
   Serial.println("Sine Wave Motor Speed Control Example");
 
   // Initialize the motor hardware abstraction layer.
-  hal_motor_init(MOTOR_PWM_A_PIN, MOTOR_PWM_B_PIN, MOTOR_BEMF_A_PIN, MOTOR_BEMF_B_PIN, NULL);
+  hal_motor_init(MOTOR_PWM_A_PIN, MOTOR_PWM_B_PIN, MOTOR_BEMF_A_PIN, MOTOR_BEMF_B_PIN, NULL, 3);
 
   // Initialize the status LED.
   status_led.begin();

--- a/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal.h
+++ b/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal.h
@@ -11,9 +11,6 @@
 
 #include <cstdint>
 
-// PWM frequency for the motor driver
-const uint32_t PWM_FREQUENCY_HZ = 2;
-
 // Delay after the PWM cycle before triggering ADC, allows the motor coils' magnetic field to collapse.
 const uint32_t BEMF_MEASUREMENT_DELAY_US = 10;
 // Ring buffer size for ADC samples. Must be a power of 2 for DMA efficiency on some platforms.
@@ -45,8 +42,9 @@ typedef void (*hal_bemf_update_callback_t)(int raw_bemf_value);
  * @param bemf_b_pin The GPIO pin number for ADC input connected to motor terminal B.
  * @param callback A pointer to a function that will be called from an interrupt
  *                 context with new BEMF data.
+ * @param pwm_frequency_hz The desired PWM frequency in Hertz. Defaults to 20kHz.
  */
-void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback);
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback, uint32_t pwm_frequency_hz = 20000);
 
 /**
  * @brief Sets the motor's PWM duty cycle and direction.

--- a/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_esp32.cpp
+++ b/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_esp32.cpp
@@ -63,10 +63,12 @@ static mcpwm_cmpr_handle_t comparator_b = nullptr;
 static mcpwm_oper_handle_t oper = nullptr;
 static mcpwm_timer_handle_t timer = nullptr;
 static gptimer_handle_t gptimer = nullptr;
+static uint32_t g_pwm_frequency_hz = 0;
 
 void hal_read_and_process_bemf();
 
-void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback) {
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback, uint32_t pwm_frequency_hz) {
+    g_pwm_frequency_hz = pwm_frequency_hz;
     g_pwm_a_pin = pwm_a_pin;
     g_pwm_b_pin = pwm_b_pin;
     g_bemf_a_pin = bemf_a_pin;
@@ -81,7 +83,7 @@ void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, ui
         .clk_src = MCPWM_TIMER_CLK_SRC_DEFAULT,
         .resolution_hz = PWM_TIMER_RESOLUTION_HZ,
         .count_mode = MCPWM_TIMER_COUNT_MODE_UP,
-        .period_ticks = PWM_TIMER_RESOLUTION_HZ / PWM_FREQUENCY_HZ,
+        .period_ticks = PWM_TIMER_RESOLUTION_HZ / g_pwm_frequency_hz,
     };
     mcpwm_new_timer(&timer_config, &timer);
 
@@ -338,7 +340,7 @@ int hal_motor_get_bemf_buffer(volatile uint16_t** buffer, int* last_write_pos) {
 }
 
 void hal_motor_set_pwm(int duty_cycle, bool forward) {
-    uint32_t duty_ticks = (PWM_TIMER_RESOLUTION_HZ / PWM_FREQUENCY_HZ) * (duty_cycle / 255.0f);
+    uint32_t duty_ticks = (PWM_TIMER_RESOLUTION_HZ / g_pwm_frequency_hz) * (duty_cycle / 255.0f);
 
     if (forward) {
         mcpwm_comparator_set_compare_value(comparator_a, duty_ticks);

--- a/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_generic.cpp
+++ b/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_generic.cpp
@@ -25,7 +25,8 @@ static hal_bemf_update_callback_t g_bemf_callback = nullptr;
 // Simulated buffer
 static volatile uint16_t s_bemf_buffer[2];
 
-void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback) {
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback, uint32_t pwm_frequency_hz) {
+    // pwm_frequency_hz is ignored in the generic HAL
     g_pwm_a_pin = pwm_a_pin;
     g_pwm_b_pin = pwm_b_pin;
     g_bemf_a_pin = bemf_a_pin;

--- a/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_nrf52.cpp
+++ b/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_nrf52.cpp
@@ -38,7 +38,7 @@ static void saadc_callback(nrfx_saadc_evt_t const * p_event) {
     }
 }
 
-void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback) {
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback, uint32_t pwm_frequency_hz) {
     bemf_callback = callback;
 
     // --- PWM Initialization ---
@@ -61,7 +61,7 @@ void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, ui
     uint32_t prescaler_divs[] = {1, 2, 4, 8, 16, 32, 64, 128};
 
     for (size_t i = 0; i < sizeof(prescalers) / sizeof(prescalers[0]); ++i) {
-        uint32_t required_top = base_clock / (prescaler_divs[i] * PWM_FREQUENCY_HZ);
+        uint32_t required_top = base_clock / (prescaler_divs[i] * pwm_frequency_hz);
         if (required_top <= 65535) {
             pwm_config.prescaler = (nrf_pwm_prescaler_t)i;
             top_value = required_top;

--- a/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_samd21.cpp
+++ b/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_samd21.cpp
@@ -84,7 +84,7 @@ void ADC_Handler() {
  *    - TC3 overflow (after 10µs) -> starts ADC conversion
  * 5. Configures the ADC to be triggered by the event system and fire an interrupt on completion.
  */
-void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback) {
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback, uint32_t pwm_frequency_hz) {
     g_pwm_a_pin = pwm_a_pin;
     g_pwm_b_pin = pwm_b_pin;
     g_bemf_a_pin = bemf_a_pin;
@@ -116,7 +116,7 @@ void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, ui
     TCC0->CTRLA.reg = TCC_CTRLA_PRESCALER_DIV1; // No prescaler, run at 48MHz
     TCC0->WAVE.reg = TCC_WAVE_WAVEGEN_NPWM; // Normal PWM mode
     while (TCC0->SYNCBUSY.bit.WAVE);
-    uint32_t period = 48000000 / PWM_FREQUENCY_HZ - 1;
+    uint32_t period = 48000000 / pwm_frequency_hz - 1;
     TCC0->PER.reg = period; // Set PWM period (wrap value)
     while (TCC0->SYNCBUSY.bit.PER);
     TCC0->EVCTRL.reg = TCC_EVCTRL_OVFEO;   // Enable overflow event output

--- a/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_stm32.cpp
+++ b/lib/xDuinoRails_MotorControl_bEMF/src/motor_control_hal_stm32.cpp
@@ -70,7 +70,7 @@ void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc) {
     process_bemf_data(bemf_ring_buffer, BEMF_RING_BUFFER_SIZE / 2);
 }
 
-void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback) {
+void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, uint8_t bemf_b_pin, hal_bemf_update_callback_t callback, uint32_t pwm_frequency_hz) {
     g_pwm_a_pin = pwm_a_pin;
     g_pwm_b_pin = pwm_b_pin;
     g_bemf_a_pin = bemf_a_pin;
@@ -87,7 +87,7 @@ void hal_motor_init(uint8_t pwm_a_pin, uint8_t pwm_b_pin, uint8_t bemf_a_pin, ui
     pwm_timer->setMode(pwm_channel_a, TIMER_OUTPUT_COMPARE_PWM1, g_pwm_a_pin);
     pwm_timer->setMode(pwm_channel_b, TIMER_OUTPUT_COMPARE_PWM1, g_pwm_b_pin);
 
-    pwm_timer->setOverflow(PWM_FREQUENCY_HZ, HERTZ_FORMAT);
+    pwm_timer->setOverflow(pwm_frequency_hz, HERTZ_FORMAT);
 
 #if defined(STM32G4)
     // --- G4 Specific Setup ---


### PR DESCRIPTION
Refactors the motor control HAL to make the PWM frequency configurable.

This change addresses a user request to visualize a slow PWM signal in the `SineWaveSpeed` example.

- Removes the hardcoded `PWM_FREQUENCY_HZ` constant from `motor_control_hal.h`.
- Adds a `pwm_frequency_hz` parameter to the `hal_motor_init` function, with a safe default of 20kHz.
- Updates all platform-specific HAL implementations to use the new parameter.
- Modifies the `SineWaveSpeed` example to set a 3s sine period and a 3Hz PWM frequency for visual testing.